### PR TITLE
Allow merging of class attributes on textareas and inputs

### DIFF
--- a/resources/views/components/horizontal-input.blade.php
+++ b/resources/views/components/horizontal-input.blade.php
@@ -9,7 +9,7 @@
                 <input id="{{ \Illuminate\Support\Str::camel($name) }}"
                     name="{{ $name }}"
                     type="{{ $type }}"
-                    class="input @if($errors->has($name)) is-danger @endif"
+                    {{ $attributes->class(['input', 'is-danger' => $errors->has($name)]) }}
                     value="{{ old($name, $value) }}"
                     @if($attributes->has('wire:model'))
                        wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}"

--- a/resources/views/components/horizontal-input.blade.php
+++ b/resources/views/components/horizontal-input.blade.php
@@ -9,14 +9,11 @@
                 <input id="{{ \Illuminate\Support\Str::camel($name) }}"
                     name="{{ $name }}"
                     type="{{ $type }}"
-                    {{ $attributes->class(['input', 'is-danger' => $errors->has($name)]) }}
+                    {{ $attributes->class(['input', 'is-danger' => $errors->has($name)])->only(['class', 'placeholder']) }}
                     value="{{ old($name, $value) }}"
-                    @if($attributes->has('wire:model'))
-                       wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}"
-                    @endif
+                   {!! $attributes->getFirstLike('wire:model') !!}
                     @if($required) required @endif
                     @if($readonly) readonly @endif
-                    @if($attributes->has('placeholder')) placeholder="{{ $attributes->get('placeholder') }}" @endif
                 />
                 <x-bbui::error name="{{ $name }}"></x-bbui::error>
             </div>

--- a/resources/views/components/horizontal-multi-checkbox.blade.php
+++ b/resources/views/components/horizontal-multi-checkbox.blade.php
@@ -8,8 +8,8 @@
             <div class="control is-expanded">
                 @foreach($options as $key => $option)
                     <div class="field">
-                        <x-bbui::checkbox :label="$option" :name="$name" :value="$key" :required="$required" 
-                            wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" 
+                        <x-bbui::checkbox :label="$option" :name="$name" :value="$key" :required="$required"
+                            wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}"
                         ></x-bbui::checkbox>
                     </div>
                 @endforeach

--- a/resources/views/components/horizontal-radio.blade.php
+++ b/resources/views/components/horizontal-radio.blade.php
@@ -14,7 +14,7 @@
                                    name="{{ $name }}"
                                    value="{{ $key }}"
                                    class="@if($errors->has($name)) is-danger @endif"
-                                   @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                                   {!! $attributes->getFirstLike('wire:model') !!}
                                    @if($required) required @endif
                                    @if($key === $value) checked @endif
                             />

--- a/resources/views/components/horizontal-select.blade.php
+++ b/resources/views/components/horizontal-select.blade.php
@@ -9,7 +9,7 @@
                 <div class="select is-fullwidth">
                     <select name="{{ $name }}" id="{{ \Illuminate\Support\Str::camel($name) }}"
                             class="@if($errors->has($name)) is-danger @endif"
-                            @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                            {!! $attributes->getFirstLike('wire:model') !!}
                             @if($required) required @endif
                     >
                         @foreach($options as $key => $option)

--- a/resources/views/components/horizontal-textarea.blade.php
+++ b/resources/views/components/horizontal-textarea.blade.php
@@ -7,7 +7,7 @@
         <div class="field">
             <div class="control is-expanded">
                 <textarea id="{{ \Illuminate\Support\Str::camel($name) }}" name="{{ $name }}"
-                    class="textarea @if($errors->has($name)) is-danger @endif"
+                    {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)]) }}
                     @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
                     @if($required) required @endif
                     @if($readonly) readonly @endif

--- a/resources/views/components/horizontal-textarea.blade.php
+++ b/resources/views/components/horizontal-textarea.blade.php
@@ -7,11 +7,10 @@
         <div class="field">
             <div class="control is-expanded">
                 <textarea id="{{ \Illuminate\Support\Str::camel($name) }}" name="{{ $name }}"
-                    {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)]) }}
-                    @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                    {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)])->only(['class', 'placeholder']) }}
+                    {!! $attributes->getFirstLike('wire:model') !!}
                     @if($required) required @endif
                     @if($readonly) readonly @endif
-                    @if($attributes->has('placeholder')) placeholder="{{ $attributes->get('placeholder') }}" @endif
                 >{{ old($name, $value) }}</textarea>
                 <x-bbui::error name="{{ $name }}"></x-bbui::error>
             </div>

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -4,7 +4,7 @@
     <div class="control">
         <input id="{{ \Illuminate\Support\Str::camel($name) }}" name="{{ $name }}"
                 type="{{ $type }}"
-                class="input @error($name) is-danger @enderror"
+                {{ $attributes->class(['input', 'is-danger' => $errors->has($name)]) }}
                 value="{{ old($name, $value) }}"
                 @if($attributes->has('wire:model'))
                     wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}"

--- a/resources/views/components/input.blade.php
+++ b/resources/views/components/input.blade.php
@@ -4,14 +4,11 @@
     <div class="control">
         <input id="{{ \Illuminate\Support\Str::camel($name) }}" name="{{ $name }}"
                 type="{{ $type }}"
-                {{ $attributes->class(['input', 'is-danger' => $errors->has($name)]) }}
+                {{ $attributes->class(['input', 'is-danger' => $errors->has($name)])->only(['class', 'placeholder']) }}
                 value="{{ old($name, $value) }}"
-                @if($attributes->has('wire:model'))
-                    wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}"
-                @endif
+                {!! $attributes->getFirstLike('wire:model') !!}
                 @if($required) required @endif
                 @if($readonly) readonly @endif
-                @if($attributes->has('placeholder')) placeholder="{{ $attributes->get('placeholder') }}" @endif
         />
         <x-bbui::error name="{{ $name }}"></x-bbui::error>
     </div>

--- a/resources/views/components/radio.blade.php
+++ b/resources/views/components/radio.blade.php
@@ -10,7 +10,7 @@
                            name="{{ $name }}"
                            value="{{ $key }}"
                            class="@if($errors->has($name)) is-danger @endif"
-                           @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                           {!! $attributes->getFirstLike('wire:model') !!}
                            @if($required) required @endif
                            @if($key === $value) checked @endif
                     />

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -6,7 +6,7 @@
             <select name="{{ $name }}"
                     id="{{ \Illuminate\Support\Str::camel($name) }}"
                     class="@if($errors->has($name)) is-danger @endif"
-                    @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                    {!! $attributes->getFirstLike('wire:model') !!}
                     @if($required) required @endif
             >
                 @foreach($options as $key => $option)

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -5,7 +5,7 @@
         <textarea id="{{ \Illuminate\Support\Str::camel($name) }}"
                   name="{{ $name }}"
                   @isset($type) type="{{ $type }}" @else type="text" @endisset
-                  class="textarea @if($errors->has($name)) is-danger @endif"
+                  {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)]) }}
                   @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
                   @if($required) required @endif
                   @if($readonly) readonly @endif

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -5,11 +5,10 @@
         <textarea id="{{ \Illuminate\Support\Str::camel($name) }}"
                   name="{{ $name }}"
                   @isset($type) type="{{ $type }}" @else type="text" @endisset
-                  {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)]) }}
-                  @if($attributes->has('wire:model')) wire:model="{{ $attributes->whereStartsWith('wire:model')->first() }}" @endif
+                  {{ $attributes->class(['textarea', 'is-danger' => $errors->has($name)])->only(['class', 'placeholder']) }}
+                  {!! $attributes->getFirstLike('wire:model') !!}
                   @if($required) required @endif
                   @if($readonly) readonly @endif
-                  @if($attributes->has('placeholder')) placeholder="{{ $attributes->get('placeholder') }}" @endif
         >{{ old($name, $value) }}</textarea>
         <x-bbui::error name="{{ $name }}"></x-bbui::error>
     </div>

--- a/src/BulmaBladeUiServiceProvider.php
+++ b/src/BulmaBladeUiServiceProvider.php
@@ -3,6 +3,7 @@
 namespace BulmaBladeUi;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\View\ComponentAttributeBag;
 
 class BulmaBladeUiServiceProvider extends ServiceProvider
 {
@@ -17,6 +18,18 @@ class BulmaBladeUiServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../resources/views' => resource_path('views/vendor/bbui'),
         ]);
+
+        ComponentAttributeBag::macro('getFirstLike', function ($search) {
+            $matches = preg_grep("/{$search}/", array_keys($this->attributes));
+
+            if(empty($matches)) {
+                return null;
+            }
+
+            $key = $matches[0];
+
+            return "{$key}=\"{$this->attributes[$key]}\"";
+        });
     }
 
     public function register()


### PR DESCRIPTION
This PR cleans up the conditional `is-danger` class addition if there are validation errors and allows the merging of other classes on the input / textarea. Use cases would be if you want to apply the respective bulma classes to modify size, state and colour.