### PR TITLE
Hide select placeholder

### DIFF
--- a/resources/views/components/horizontal-select.blade.php
+++ b/resources/views/components/horizontal-select.blade.php
@@ -12,7 +12,7 @@
                             @if($required) required @endif
                     >
                         @if($attributes->has('placeholder'))
-                            <option value="">{{ $attributes->get('placeholder') }}</option>
+                            <option value="" hidden>{{ $attributes->get('placeholder') }}</option>
                         @endif
                         @foreach($options as $key => $option)
                             <option value="{{ $key }}" @if($key == $value) selected @endif>

--- a/resources/views/components/horizontal-select.blade.php
+++ b/resources/views/components/horizontal-select.blade.php
@@ -1,4 +1,4 @@
-@props(['label', 'name' => '', 'options' => [], 'value' => '', 'required' => false])
+@props(['label', 'name' => '', 'options' => [], 'value' => '', 'required' => false, 'hidePlaceholderFromSelection' => false])
 <div class="field is-horizontal">
     <div class="field-label is-normal">
         <label class="label" for="{{ \Illuminate\Support\Str::camel($name) }}">{{ $label}}</label>
@@ -12,7 +12,7 @@
                             @if($required) required @endif
                     >
                         @if($attributes->has('placeholder'))
-                            <option value="" hidden>{{ $attributes->get('placeholder') }}</option>
+                            <option value="" @if($hidePlaceholderFromSelection) hidden @endif>{{ $attributes->get('placeholder') }}</option>
                         @endif
                         @foreach($options as $key => $option)
                             <option value="{{ $key }}" @if($key == $value) selected @endif>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -1,4 +1,4 @@
-@props(['label', 'name' => '', 'options' => [], 'value' => '', 'required' => false])
+@props(['label', 'name' => '', 'options' => [], 'value' => '', 'required' => false, 'hidePlaceholderFromSelection' => false])
 <div class="field">
     <label class="label" for="{{ \Illuminate\Support\Str::camel($name) }}">{{ $label }}</label>
     <div class="control">
@@ -9,7 +9,7 @@
                     @if($required) required @endif
             >
                 @if($attributes->has('placeholder'))
-                    <option value="" hidden>{{ $attributes->get('placeholder') }}</option>
+                    <option value="" @if($hidePlaceholderFromSelection) hidden @endif>{{ $attributes->get('placeholder') }}</option>
                 @endif
                 @foreach($options as $key => $option)
                     <option value="{{ $key }}" @if($key === $value) selected @endif>

--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -9,7 +9,7 @@
                     @if($required) required @endif
             >
                 @if($attributes->has('placeholder'))
-                    <option value="">{{ $attributes->get('placeholder') }}</option>
+                    <option value="" hidden>{{ $attributes->get('placeholder') }}</option>
                 @endif
                 @foreach($options as $key => $option)
                     <option value="{{ $key }}" @if($key === $value) selected @endif>

--- a/tests/Components/HorizontalSelectTest.php
+++ b/tests/Components/HorizontalSelectTest.php
@@ -45,6 +45,6 @@ class HorizontalSelectTest extends TestCase
                 ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option']
             );
 
-        $view->assertSee('<option value="">Select an option</option>', false);
+        $view->assertSee('<option value="" hidden>Select an option</option>', false);
     }
 }

--- a/tests/Components/HorizontalSelectTest.php
+++ b/tests/Components/HorizontalSelectTest.php
@@ -45,6 +45,18 @@ class HorizontalSelectTest extends TestCase
                 ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option']
             );
 
-        $view->assertSee('<option value="" hidden>Select an option</option>', false);
+        $view->assertSee('<option value="" >Select an option</option>', false);
+    }
+
+    /** @test */
+    public function horizontal_select_render_placeholder_but_hides_it_from_selection_when_set()
+    {
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-bbui::'.$this->component.' :label="$label" :name="$name" :options="$options" :placeholder="$placeholder" :hide-placeholder-from-selection="$hidePlaceholderFromSelection"></x-bbui::'.$this->component.'>',
+                ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option', 'hidePlaceholderFromSelection' => true]
+            );
+
+        $view->assertSee('<option value=""  hidden >Select an option</option>', false);
     }
 }

--- a/tests/Components/SelectTest.php
+++ b/tests/Components/SelectTest.php
@@ -45,6 +45,18 @@ class SelectTest extends TestCase
                 ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option']
             );
 
-        $view->assertSee('<option value="" hidden>Select an option</option>', false);
+        $view->assertSee('<option value="" >Select an option</option>', false);
+    }
+
+    /** @test */
+    public function select_render_placeholder_but_hides_it_from_selection_when_set()
+    {
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-bbui::'.$this->component.' :label="$label" :name="$name" :options="$options" :placeholder="$placeholder" :hide-placeholder-from-selection="$hidePlaceholderFromSelection"></x-bbui::'.$this->component.'>',
+                ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option', 'hidePlaceholderFromSelection' => true]
+            );
+
+        $view->assertSee('<option value=""  hidden >Select an option</option>', false);
     }
 }

--- a/tests/Components/SelectTest.php
+++ b/tests/Components/SelectTest.php
@@ -45,6 +45,6 @@ class SelectTest extends TestCase
                 ['label' => 'The Input Label', 'name' => 'test', 'options' => ['first' => 'First option'], 'placeholder' => 'Select an option']
             );
 
-        $view->assertSee('<option value="">Select an option</option>', false);
+        $view->assertSee('<option value="" hidden>Select an option</option>', false);
     }
 }


### PR DESCRIPTION
A little feature that will allow the placeholder to be displayed when nothing is selected but will not show it in the list of values available to be selected