### PR TITLE
Move PHPUnit dependency to development.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,6 @@
             "email": "csrhymes@gmail.com"
         }
     ],
-    "require": {
-        "phpunit/phpunit": "^9.5"
-    },
     "autoload": {
         "psr-4": {
             "BulmaBladeUi\\": "src"
@@ -30,6 +27,7 @@
         }
     },
     "require-dev": {
+        "phpunit/phpunit": "^9.5",
         "orchestra/testbench": "^6.11"
     },
     "scripts": {


### PR DESCRIPTION
There is no need to have it as a hard dependency and block using this project with a different version constraint (as in laravel 10)
